### PR TITLE
Adapt env to fetch in render in production and localhost in development

### DIFF
--- a/frontend/src/geoChecker/services/authService.ts
+++ b/frontend/src/geoChecker/services/authService.ts
@@ -1,4 +1,4 @@
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000/api';
+const API_URL = import.meta.env.VITE_API_URL || 'https://geochecker.onrender.com/api';
 
 export interface LoginResponse {
   token: string;


### PR DESCRIPTION
- Adapt the service with render url so it will fetch data from render if the environment is production, and localhost if the environment is development